### PR TITLE
fix: removeu tags redundantes, moveu tags para index

### DIFF
--- a/ArchSpot-FrontEnd/archspot-angular/src/app/auth/login/login.component.html
+++ b/ArchSpot-FrontEnd/archspot-angular/src/app/auth/login/login.component.html
@@ -1,23 +1,3 @@
-<!doctype html>
-<html lang="en">
-
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Login | ArchSpot</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-  <link rel="stylesheet" href="/styles.css">
-
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
-    href="https://fonts.googleapis.com/css2?family=Josefin+Sans:ital,wght@0,100..700;1,100..700&family=Josefin+Slab:ital,wght@0,100..700;1,100..700&display=swap"
-    rel="stylesheet">
-</head>
-
-<body>
-
   <app-navbar></app-navbar>
 
   <div class="container py-5 mt-4">
@@ -81,12 +61,3 @@
   </div>
 
   <app-footer></app-footer>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-    crossorigin="anonymous"></script>
-  <script src="https://code.jquery.com/jquery-3.7.1.min.js"
-    integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-</body>
-
-</html>

--- a/ArchSpot-FrontEnd/archspot-angular/src/index.html
+++ b/ArchSpot-FrontEnd/archspot-angular/src/index.html
@@ -1,13 +1,22 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>ArchSpot</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="assets/img/icons/iconsvg.ico">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Josefin+Sans:ital,wght@0,100..700;1,100..700&family=Josefin+Slab:ital,wght@0,100..700;1,100..700&display=swap"
+    rel="stylesheet">
 </head>
+
 <body>
   <app-root></app-root>
 </body>
+
 </html>


### PR DESCRIPTION
- Removidas do componente de página de login, as tags `<html>`, `<head> `e `<body> `- _em um projeto angular, apenas o **index.html** vai levar essas tags e a partir dele os demais componentes são carregados_.
- os `<script> ` do cdn bootstrap.js foram removidos: estamos usando ng-bootstrap e aplicar ambos pode gerar conflito.
- os `<script>` do jQuery também foram removidos pelos mesmos motivos.
- os `<link>` do bootstrap css e o arquivo externo **style.css** já são carregados no arquivo de configuração **angular.json**.
- os `<link>` para as fontes específicas do projeto foram movidas para o `<head>` do **index.html**.