### PR TITLE
fix: dropdowwn menu na navbar

### DIFF
--- a/ArchSpot-FrontEnd/archspot-angular/src/app/layout/layout.module.ts
+++ b/ArchSpot-FrontEnd/archspot-angular/src/app/layout/layout.module.ts
@@ -1,12 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NavbarComponent } from './navbar/navbar.component';
+import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 
 
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule,
+    NgbDropdownModule
   ]
 })
 export class LayoutModule { }

--- a/ArchSpot-FrontEnd/archspot-angular/src/app/layout/navbar/navbar.component.css
+++ b/ArchSpot-FrontEnd/archspot-angular/src/app/layout/navbar/navbar.component.css
@@ -1,0 +1,11 @@
+.dropdown-menu {
+  background-color: #78A58B !important; /* mesma cor da navbar */
+  border: none;
+}
+
+
+
+.dropdown-item:hover {
+  background-color: #78A58B; /* tom mais escuro para hover */
+  color: #fff;
+}

--- a/ArchSpot-FrontEnd/archspot-angular/src/app/layout/navbar/navbar.component.html
+++ b/ArchSpot-FrontEnd/archspot-angular/src/app/layout/navbar/navbar.component.html
@@ -1,52 +1,56 @@
 <nav class="navbar navbar-expand-lg fixed-top" data-bs-theme="dark" style="background-color: #78A58B;">
   <div class="container-fluid">
-    <div class="rounded" style="background-color: #19535F;">
+    <div class="rounded" style="background-color: #19535F;"></div>
 
-    </div>
     <a class="navbar-brand" href="#">
-      <img src="assets/img/icon.jpg" alt="" class="rounded-circle me-1 d-inline-block align-text-middle" width="30"
-        height="30">
-      <span class="font-logo">ArchSpot</span></a>
+      <img src="assets/img/icon.jpg" alt="" class="rounded-circle me-1 d-inline-block align-text-middle" width="30" height="30">
+      <span class="font-logo">ArchSpot</span>
+    </a>
+
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
+
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav m-auto mb-2 mb-lg-0">
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="#">Home</a>
         </li>
+
         <li class="nav-item">
           <a class="nav-link" aria-current="page" href="#">Projetos</a>
         </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+
+        <!-- Dropdown Cadastros -->
+        <li class="nav-item dropdown" ngbDropdown>
+          <a class="nav-link dropdown-toggle" ngbDropdownToggle href="#">
             Cadastros
           </a>
-          <ul class="dropdown-menu">
+          <ul ngbDropdownMenu class="dropdown-menu">
             <li><a class="dropdown-item" href="#">Clientes</a></li>
             <li><a class="dropdown-item" href="#">Projetistas</a></li>
           </ul>
         </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+
+        <!-- Dropdown Planos -->
+        <li class="nav-item dropdown" ngbDropdown>
+          <a class="nav-link dropdown-toggle" ngbDropdownToggle href="#">
             Planos
           </a>
-          <ul class="dropdown-menu">
+          <ul ngbDropdownMenu class="dropdown-menu">
             <li><a class="dropdown-item" href="#">Plano Livre</a></li>
             <li><a class="dropdown-item" href="#">Plano Autônomo</a></li>
             <li><a class="dropdown-item" href="#">Plano Empresa</a></li>
-            <li>
-              <hr class="dropdown-divider">
-            </li>
+            <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" href="#">Conheça mais...</a></li>
           </ul>
         </li>
       </ul>
 
-      <a role="button" href="#"
-        class="fs-5 link-light link-underline link-underline-opacity-0 link-underline-opacity-75-hover">
-        Ana<img src="assets/img/personas/ana.jpeg" class="rounded-circle ms-2" width="35" height="35">
+      <a role="button" href="#" class="fs-5 link-light link-underline link-underline-opacity-0 link-underline-opacity-75-hover">
+        Ana
+        <img src="assets/img/personas/ana.jpeg" class="rounded-circle ms-2" width="35" height="35">
       </a>
     </div>
   </div>


### PR DESCRIPTION
- adequados os menus dropdown da navbar para o `ngbDropdown`
- importado o modulo `NgbDropdownModule` em **layout.module.ts**
- sobrescrito o estilo em **navbar.component.css** para o dropdown acompanhar a mesma estilização

> **Importante**: Lembrar de verificar um dia porque o menu "sanduiche" não funciona quando a navbar colapsa (em exibição de telas estreitas, por exemplo)... tem a ver com .js do bootstrap, por usar ngbootstrap tem que resolver na mão.. vai ficar para a próxima.