### PR TITLE
fix: máscaras nos campos de cadastro

### DIFF
--- a/ArchSpot-FrontEnd/archspot-angular/package-lock.json
+++ b/ArchSpot-FrontEnd/archspot-angular/package-lock.json
@@ -19,6 +19,7 @@
         "@ng-bootstrap/ng-bootstrap": "^17.0.1",
         "@popperjs/core": "^2.11.8",
         "bootstrap": "^5.3.2",
+        "ngx-mask": "^19.0.7",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.10"
@@ -9884,6 +9885,20 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ngx-mask": {
+      "version": "19.0.7",
+      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-19.0.7.tgz",
+      "integrity": "sha512-Zkv/bVuXMTAPsm5yL9BVnj1AKQSc/FQ4jmN1f8ZAa0wL4/rzm8EgTcXahP+eqG+GGUDP4e6RcipfKqzFeBdsKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=14.0.0",
+        "@angular/core": ">=14.0.0",
+        "@angular/forms": ">=14.0.0"
+      }
     },
     "node_modules/nice-napi": {
       "version": "1.0.2",

--- a/ArchSpot-FrontEnd/archspot-angular/package.json
+++ b/ArchSpot-FrontEnd/archspot-angular/package.json
@@ -21,6 +21,7 @@
     "@ng-bootstrap/ng-bootstrap": "^17.0.1",
     "@popperjs/core": "^2.11.8",
     "bootstrap": "^5.3.2",
+    "ngx-mask": "^19.0.7",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.10"

--- a/ArchSpot-FrontEnd/archspot-angular/src/app/shared/modal-cadastro/modal-cadastro.component.html
+++ b/ArchSpot-FrontEnd/archspot-angular/src/app/shared/modal-cadastro/modal-cadastro.component.html
@@ -20,7 +20,7 @@
 
         <div class="mb-3">
             <label for="cpf" class="form-label">CPF:</label>
-            <input type="number" class="form-control" name="cpf" id="cpf" required />
+            <input type="text" mask="000.000.000-00" class="form-control" name="cpf" id="cpf" required />
         </div>
 
         <div class="mb-3">
@@ -35,7 +35,7 @@
 
         <div class="mb-3">
             <label for="telefone" class="form-label">Telefone:</label>
-            <input type="text" class="form-control" name="phone" id="phone" required />
+            <input type="text" mask="(00) 00000-0000" class="form-control" name="phone" id="phone" required />
         </div>
 
         <div class="mb-3">

--- a/ArchSpot-FrontEnd/archspot-angular/src/app/shared/modal-cadastro/modal-cadastro.component.ts
+++ b/ArchSpot-FrontEnd/archspot-angular/src/app/shared/modal-cadastro/modal-cadastro.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { FormsModule, NgForm } from '@angular/forms';
+import { NgForm } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({

--- a/ArchSpot-FrontEnd/archspot-angular/src/app/shared/shared.module.ts
+++ b/ArchSpot-FrontEnd/archspot-angular/src/app/shared/shared.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ModalCadastroComponent } from './modal-cadastro/modal-cadastro.component';
 import { FormsModule } from '@angular/forms';
 import { ProjectStatusBarComponent } from './components/project-status-bar/project-status-bar.component';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 
 
@@ -13,10 +14,14 @@ import { ProjectStatusBarComponent } from './components/project-status-bar/proje
   ],
   imports: [
     CommonModule,
-    FormsModule
+    FormsModule,
+    NgxMaskDirective
   ],
   exports: [
     ProjectStatusBarComponent
+  ],
+  providers: [
+    provideNgxMask()
   ]
 })
 export class SharedModule { }


### PR DESCRIPTION
closes #50 - Máscaras de input utilizando o ngx-mask do angular. 

> (CONSEGUI 👍 😄  )

- Instalada a dependência ngx-mask 19.0.7;
- Importado em shared.module.ts o **NgxMaskDirective** e o provider **provideNgxMask()**
- Máscaras aplicadas em CPF e Telefone.

